### PR TITLE
Typo in npm instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ hit that goal and still get our metadata.
 ## Usage
 
 ````
-npm install node-image-headers
+npm install image-headers
 ````
 
 See the test file for how we are using it. Here's the key snippet:


### PR DESCRIPTION
Thanks for great library, exactly what I needed. I saw a small error in the readme. 
